### PR TITLE
Add Authorization Feature to AspNetCoreHealth

### DIFF
--- a/src/App.Metrics.AspNetCore.Health.Core/Internal/Authorization/AuthorizedHealthAuthorizationFilter.cs
+++ b/src/App.Metrics.AspNetCore.Health.Core/Internal/Authorization/AuthorizedHealthAuthorizationFilter.cs
@@ -1,0 +1,15 @@
+﻿// <copyright file="AuthorizedHealthAuthorizationFilter.cs" company="Allan Hardy">
+// Copyright (c) Allan Hardy. All rights reserved.
+// </copyright>
+
+using System.Threading;
+using Microsoft.AspNetCore.Http;
+
+namespace App.Metrics.AspNetCore.Health
+{
+  public class AuthorizedHealthAuthorizationFilter : IHealthAuthorizationFilter
+  {
+    /// <inheritdoc />
+    public bool Authorized(HttpContext context, CancellationToken token = default) { return true; }
+  }
+}

--- a/src/App.Metrics.AspNetCore.Health.Core/Internal/Authorization/IHealthAuthorizationFilter.cs
+++ b/src/App.Metrics.AspNetCore.Health.Core/Internal/Authorization/IHealthAuthorizationFilter.cs
@@ -1,0 +1,14 @@
+﻿// <copyright file="IHealthAuthorizationFilter.cs" company="Allan Hardy">
+// Copyright (c) Allan Hardy. All rights reserved.
+// </copyright>
+
+using System.Threading;
+using Microsoft.AspNetCore.Http;
+
+namespace App.Metrics.AspNetCore.Health
+{
+  public interface IHealthAuthorizationFilter
+  {
+    bool Authorized(HttpContext context, CancellationToken token = default);
+  }
+}

--- a/src/App.Metrics.AspNetCore.Health.Core/Internal/Authorization/NotAuthorizedHealthAuthorizationFilter.cs
+++ b/src/App.Metrics.AspNetCore.Health.Core/Internal/Authorization/NotAuthorizedHealthAuthorizationFilter.cs
@@ -1,0 +1,15 @@
+﻿// <copyright file="NotAuthorizedHealthAuthorizationFilter.cs" company="Allan Hardy">
+// Copyright (c) Allan Hardy. All rights reserved.
+// </copyright>
+
+using System.Threading;
+using Microsoft.AspNetCore.Http;
+
+namespace App.Metrics.AspNetCore.Health
+{
+  public class NotAuthorizedHealthAuthorizationFilter : IHealthAuthorizationFilter
+  {
+    /// <inheritdoc />
+    public bool Authorized(HttpContext context, CancellationToken token = default) { return false; }
+  }
+}

--- a/src/App.Metrics.AspNetCore.Health.Core/Internal/Extensions/AppMetricsMiddlewareHealthChecksLoggerExtensions.cs
+++ b/src/App.Metrics.AspNetCore.Health.Core/Internal/Extensions/AppMetricsMiddlewareHealthChecksLoggerExtensions.cs
@@ -33,6 +33,14 @@ namespace Microsoft.Extensions.Logging
             }
         }
 
+        public static void MiddlewareAuthorizationInvalid<TMiddleware>(this ILogger logger)
+        {
+          if (logger.IsEnabled(LogLevel.Trace))
+          {
+            logger.LogTrace(AppMetricsEventIds.Middleware.MiddlewareAuthorizationInvalidId, $"Invalid authorization App Metrics Health Middleware {typeof(TMiddleware).FullName}");
+          }
+        }
+
         private static class AppMetricsEventIds
         {
             public static class Middleware
@@ -40,6 +48,7 @@ namespace Microsoft.Extensions.Logging
                 public const int MiddlewareExecutedId = 1;
                 public const int MiddlewareExecutingId = 2;
                 public const int MiddlewareErrorId = 3;
+                public const int MiddlewareAuthorizationInvalidId = 4;
             }
         }
     }

--- a/src/App.Metrics.AspNetCore.Health.Endpoints/Builder/HealthApplicationBuilderExtensions.cs
+++ b/src/App.Metrics.AspNetCore.Health.Endpoints/Builder/HealthApplicationBuilderExtensions.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System;
+using App.Metrics.AspNetCore.Health;
 using App.Metrics.AspNetCore.Health.Endpoints;
 using App.Metrics.AspNetCore.Health.Endpoints.Middleware;
 using App.Metrics.Health;
@@ -112,7 +113,8 @@ namespace Microsoft.AspNetCore.Builder
                 appBuilder =>
                 {
                     var responseWriter = HealthAspNetCoreHealthEndpointsServiceCollectionExtensions.ResolveHealthResponseWriter(app.ApplicationServices, formatter);
-                    appBuilder.UseMiddleware<HealthCheckEndpointMiddleware>(responseWriter, endpointsOptionsAccessor.Value.Timeout);
+                    var healthAuthorizationFilter = app.ApplicationServices.GetService<IHealthAuthorizationFilter>() ?? new AuthorizedHealthAuthorizationFilter();
+                    appBuilder.UseMiddleware<HealthCheckEndpointMiddleware>(responseWriter, endpointsOptionsAccessor.Value.Timeout, healthAuthorizationFilter);
                 });
         }
     }

--- a/test/App.Metrics.AspNetCore.Health.Integration.Facts/Middleware/HealthCheckEndpointAuthorizationMiddleware.cs
+++ b/test/App.Metrics.AspNetCore.Health.Integration.Facts/Middleware/HealthCheckEndpointAuthorizationMiddleware.cs
@@ -1,0 +1,31 @@
+﻿// <copyright file="HealthCheckEndpointAuthorizationMiddleware.cs" company="Allan Hardy">
+// Copyright (c) Allan Hardy. All rights reserved.
+// </copyright>
+
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using App.Metrics.AspNetCore.Health.Integration.Facts.Startup;
+using FluentAssertions;
+using Xunit;
+
+namespace App.Metrics.AspNetCore.Health.Integration.Facts.Middleware
+{
+  public class HealthCheckEndpointAuthorizationMiddleware : IClassFixture<StartupTestFixture<NotAuthorizedHealthTestStartup>>
+  {
+    public HealthCheckEndpointAuthorizationMiddleware(StartupTestFixture<NotAuthorizedHealthTestStartup> fixture)
+    {
+      Client = fixture.Client;
+    }
+
+    private HttpClient Client { get; }
+
+    [Fact]
+    public async Task Returns_correct_response_headers_not_authorized()
+    {
+      var result = await Client.GetAsync("/health");
+
+      result.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+  }
+}

--- a/test/App.Metrics.AspNetCore.Health.Integration.Facts/Startup/NotAuthorizedHealthTestStartup.cs
+++ b/test/App.Metrics.AspNetCore.Health.Integration.Facts/Startup/NotAuthorizedHealthTestStartup.cs
@@ -1,0 +1,37 @@
+﻿// <copyright file="NotAuthorizedHealthTestStartup.cs" company="Allan Hardy">
+// Copyright (c) Allan Hardy. All rights reserved.
+// </copyright>
+
+using App.Metrics.AspNetCore.Health.Endpoints;
+using App.Metrics.Health;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace App.Metrics.AspNetCore.Health.Integration.Facts.Startup
+{
+  // ReSharper disable ClassNeverInstantiated.Global
+  public class NotAuthorizedHealthTestStartup : TestStartup
+    // ReSharper restore ClassNeverInstantiated.Global
+  {
+    public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+    {
+      app.UseHealthEndpoint();
+
+      SetupAppBuilder(app, env, loggerFactory);
+    }
+
+    public void ConfigureServices(IServiceCollection services)
+    {
+      services.AddSingleton<IHealthAuthorizationFilter, NotAuthorizedHealthAuthorizationFilter>();
+
+      var appMetricsMiddlewareHealthCheckOptions = new HealthEndpointsOptions();
+
+      SetupServices(
+        services,
+        appMetricsMiddlewareHealthCheckOptions,
+        healthChecks: new[] { HealthCheckResult.Healthy() });
+    }
+  }
+}


### PR DESCRIPTION
### The issue or feature being addressed

https://github.com/AppMetrics/AppMetrics/issues/366

### Details on the issue fix or feature implementation

Add Authorization Feature to AspNetCoreHealth. Instead of implementing Authorization details in AspNetCoreHealth use dependency injection with IHealthAuthorizationFilter interface to allow the calling application to implement their own Authorization Mechanism. The HttpContext context is passed into the IHealthAuthorizationFilter Authorized method because the most likely scenario is the caller will want to check for an Authorization headers and secrets.


### Confirm the following

- [X ] I have ensured that I have merged the latest changes from the dev branch
- [X ] I have successfully run a [local build](https://github.com/alhardy/AppMetrics#how-to-build)
- [X ] I have included unit tests for the issue/feature
- [X] I have included the github issue number in my commits 